### PR TITLE
Fix missing write permission for GitHub Actions

### DIFF
--- a/.github/workflows/laravel/pint.yml
+++ b/.github/workflows/laravel/pint.yml
@@ -6,7 +6,10 @@ on:
 jobs:
   laravel-pint:
     runs-on: ubuntu-latest
-    
+
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -6,7 +6,10 @@ on:
 jobs:
   php-cs-fixer:
     runs-on: ubuntu-latest
-    
+
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -8,6 +8,9 @@ jobs:
   update:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## What does this pull request do?

Fixes missing write permission for GitHub Actions.

## Why is this pull request needed?

https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/
